### PR TITLE
feat: Nonstreaming API

### DIFF
--- a/apps/desktop/src-tauri/src/inference/completion.rs
+++ b/apps/desktop/src-tauri/src/inference/completion.rs
@@ -35,7 +35,7 @@ pub struct CompletionRequest {
 
   sampler: Option<String>,
 
-  stream: Option<bool>,
+  pub stream: Option<bool>,
 
   max_tokens: Option<usize>,
 

--- a/apps/desktop/src-tauri/src/inference/process.rs
+++ b/apps/desktop/src-tauri/src/inference/process.rs
@@ -110,7 +110,7 @@ pub fn start<'a>(req: InferenceThreadRequest) -> JoinHandle<()> {
 
     println!("Feeding prompt ...");
 
-    if (stream_enabled) {
+    if stream_enabled {
       req.send_event("FEEDING_PROMPT");
     }
 
@@ -125,7 +125,7 @@ pub fn start<'a>(req: InferenceThreadRequest) -> JoinHandle<()> {
         }
 
         if let Some(token) = token_utf8_buf.push(t) {
-          if (stream_enabled) {
+          if stream_enabled {
             req.send_comment(format!("Processing token: {:?}", token).as_str());
           }
         }
@@ -147,7 +147,7 @@ pub fn start<'a>(req: InferenceThreadRequest) -> JoinHandle<()> {
       }
     };
 
-    if (stream_enabled) {
+    if stream_enabled {
       req.send_comment("Generating tokens ...");
       req.send_event("GENERATING_TOKENS");
     }
@@ -211,7 +211,7 @@ pub fn start<'a>(req: InferenceThreadRequest) -> JoinHandle<()> {
 
     println!("Inference stats: {:?}", stats);
 
-    if (stream_enabled) {
+    if stream_enabled {
       if !req.token_sender.is_disconnected() {
         req.send_done();
       }

--- a/apps/desktop/src-tauri/src/inference/process.rs
+++ b/apps/desktop/src-tauri/src/inference/process.rs
@@ -22,7 +22,7 @@ pub struct InferenceThreadRequest {
   pub abort_flag: Arc<RwLock<bool>>,
   pub model_guard: ModelGuard,
   pub completion_request: CompletionRequest,
-  pub nonstream_str_buf: Arc<Mutex<String>>,
+  pub nonstream_completion_tokens: Arc<Mutex<String>>,
   pub stream: bool,
   pub tx: Option<Sender<()>>,
 }
@@ -89,7 +89,7 @@ pub fn start<'a>(req: InferenceThreadRequest) -> JoinHandle<()> {
     let mut token_utf8_buf = TokenUtf8Buffer::new();
     let guard = req.model_guard.lock();
     let stream_enabled = req.stream;
-    let mut nonstream_res_str_buf = req.nonstream_str_buf.lock();
+    let mut nonstream_res_str_buf = req.nonstream_completion_tokens.lock();
 
     let model = match guard.as_ref() {
       Some(m) => m,

--- a/apps/desktop/src-tauri/src/inference/process.rs
+++ b/apps/desktop/src-tauri/src/inference/process.rs
@@ -20,9 +20,11 @@ pub type ModelGuard = Arc<Mutex<Option<Box<dyn Model>>>>;
 pub struct InferenceThreadRequest {
   pub token_sender: Sender<Bytes>,
   pub abort_flag: Arc<RwLock<bool>>,
-
   pub model_guard: ModelGuard,
   pub completion_request: CompletionRequest,
+  pub nonstream_str_buf: Arc<Mutex<String>>,
+  pub stream: bool,
+  pub tx: Option<Sender<()>>,
 }
 
 impl InferenceThreadRequest {
@@ -77,7 +79,7 @@ fn get_inference_params(
 }
 
 // Perhaps might be better to clone the model for each thread...
-pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
+pub fn start<'a>(req: InferenceThreadRequest) -> JoinHandle<()> {
   println!("Spawning inference thread...");
   actix_web::rt::task::spawn_blocking(move || {
     let mut rng = req.completion_request.get_rng();
@@ -86,6 +88,8 @@ pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
 
     let mut token_utf8_buf = TokenUtf8Buffer::new();
     let guard = req.model_guard.lock();
+    let stream_enabled = req.stream;
+    let mut nonstream_res_str_buf = req.nonstream_str_buf.lock();
 
     let model = match guard.as_ref() {
       Some(m) => m,
@@ -105,7 +109,10 @@ pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
     let start_at = std::time::SystemTime::now();
 
     println!("Feeding prompt ...");
-    req.send_event("FEEDING_PROMPT");
+
+    if (stream_enabled) {
+      req.send_event("FEEDING_PROMPT");
+    }
 
     match session.feed_prompt::<Infallible, Prompt>(
       model.as_ref(),
@@ -118,7 +125,9 @@ pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
         }
 
         if let Some(token) = token_utf8_buf.push(t) {
-          req.send_comment(format!("Processing token: {:?}", token).as_str());
+          if (stream_enabled) {
+            req.send_comment(format!("Processing token: {:?}", token).as_str());
+          }
         }
 
         Ok(InferenceFeedback::Continue)
@@ -138,8 +147,10 @@ pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
       }
     };
 
-    req.send_comment("Generating tokens ...");
-    req.send_event("GENERATING_TOKENS");
+    if (stream_enabled) {
+      req.send_comment("Generating tokens ...");
+      req.send_event("GENERATING_TOKENS");
+    }
 
     // Reset the utf8 buf
     token_utf8_buf = TokenUtf8Buffer::new();
@@ -176,14 +187,19 @@ pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
 
       // Buffer the token until it's valid UTF-8, then call the callback.
       if let Some(tokens) = token_utf8_buf.push(&token) {
-        match req
-          .token_sender
-          .send(CompletionResponse::to_data_bytes(tokens))
-        {
-          Ok(_) => {}
-          Err(_) => {
-            break;
+        if req.stream {
+          match req
+            .token_sender
+            .send(CompletionResponse::to_data_bytes(tokens))
+          {
+            Ok(_) => {}
+            Err(_) => {
+              break;
+            }
           }
+        } else {
+          //Collect tokens into str buffer
+          *nonstream_res_str_buf += &tokens;
         }
       }
 
@@ -195,8 +211,15 @@ pub fn start(req: InferenceThreadRequest) -> JoinHandle<()> {
 
     println!("Inference stats: {:?}", stats);
 
-    if !req.token_sender.is_disconnected() {
-      req.send_done();
+    if (stream_enabled) {
+      if !req.token_sender.is_disconnected() {
+        req.send_done();
+      }
+    } else {
+      if let Some(tx) = req.tx {
+        //Tell server thread that inference completed, and let it respond
+        let _ = tx.send(());
+      }
     }
 
     // TODO: Might make this into a callback later, for now we just abuse the singleton

--- a/apps/desktop/src-tauri/src/inference/server.rs
+++ b/apps/desktop/src-tauri/src/inference/server.rs
@@ -4,6 +4,7 @@ use actix_web::web::{Bytes, Json};
 use actix_web::{get, post, App, HttpResponse, HttpServer, Responder};
 use parking_lot::{Mutex, RwLock};
 use serde::Serialize;
+use serde_json::json;
 
 use std::sync::{
   atomic::{AtomicBool, Ordering},
@@ -97,10 +98,14 @@ async fn post_completions(payload: Json<CompletionRequest>) -> impl Responder {
     rx.recv().unwrap();
 
     let locked_str_buffer = str_buffer.lock();
+    let completion_body = json!({
+      "completion": locked_str_buffer.clone()
+    });
+
     HttpResponse::Ok()
       .append_header(("Content-Type", "text/plain"))
       .append_header(("Cache-Control", "no-cache"))
-      .json(locked_str_buffer.clone())
+      .json(completion_body)
   }
 }
 


### PR DESCRIPTION
The implementation uses the same `start` function inside `process.rs` for multithreading but just doesn't send server events back to the request sender on every new token but collects the tokens into a string buffer.

Currently, there is no client-side implementation, so merging should not affect client-side at all. Next, we could open an issue for client-side implementation as well.

Here is a request body for quickly testing the API (stream flag is false):

`{"sampler":"top-p-top-k","prompt":"AI: Greeting! I am a friendly AI assistant. Feel free to ask me anything.\nHuman: Hello world\nAI: ","max_tokens":200,"temperature":1,"seed":147,"frequency_penalty":0.6,"presence_penalty":0,"top_k":42,"top_p":1,"stop":["AI: ","Human: "],"stream":false}`

[Issue](https://github.com/louisgv/local.ai/issues/75)