### PR TITLE
feat: move /completions under /v1/completions

### DIFF
--- a/apps/desktop/src-tauri/src/inference/server.rs
+++ b/apps/desktop/src-tauri/src/inference/server.rs
@@ -39,7 +39,7 @@ async fn post_model() -> impl Responder {
   })
 }
 
-#[post("/completions")]
+#[post("/v1/completions")]
 async fn post_completions(payload: Json<CompletionRequest>) -> impl Responder {
   println!("Received completion request: {:?}", payload.0);
 

--- a/apps/desktop/src-tauri/src/inference/server.rs
+++ b/apps/desktop/src-tauri/src/inference/server.rs
@@ -32,7 +32,7 @@ struct ModelInfo {
   id: String,
 }
 
-#[post("/model")]
+#[post("/v1/models")]
 async fn post_model() -> impl Responder {
   HttpResponse::Ok().json(ModelInfo {
     id: String::from("local.ai"),

--- a/apps/desktop/src/providers/thread.ts
+++ b/apps/desktop/src/providers/thread.ts
@@ -134,7 +134,7 @@ const useThreadProvider = ({ thread }: { thread: FileInfo }) => {
       })
 
       const fetchStream = await globalThis.fetch(
-        `http://localhost:${serverConfig.data.port}/completions`,
+        `http://localhost:${serverConfig.data.port}/v1/completions`,
         {
           method: "POST",
           keepalive: true,


### PR DESCRIPTION
This PR updates the server endpoints in local.ai to match the endpoints from llama-cpp-python.
Specifically it changes `/completions` to `/v1/completions` as in [llama-cpp-python/llama_cpp/server/app.py:599](https://github.com/abetlen/llama-cpp-python/blob/main/llama_cpp/server/app.py#L599)
And `/model` to `/v1/models` as in [llama-cpp-python/llama_cpp/server/app.py:805](https://github.com/abetlen/llama-cpp-python/blob/main/llama_cpp/server/app.py#L805)